### PR TITLE
Adding links for testnet page that were missing.

### DIFF
--- a/src/testnet.hbs
+++ b/src/testnet.hbs
@@ -11,7 +11,7 @@
             Ellaism has a Proof of Authority (PoA) testnet called “Shikinseki”. 
             <br>
             To connect to the testnet,
-             <a href="" class="bl-text-secondary">
+             <a href="https://raw.githubusercontent.com/ellaism/parity-config/master/shikinseki.json" class="bl-text-secondary">
                   download
                 </a>
                 this file and run:
@@ -26,8 +26,8 @@
             Additional facilities you can use on the testnet:
           </p>
            <ul class="bl-list-bullet bl-spacer-b-m-40 bl-spacer-l-m-40 bl-spacer-mob-l-m-30">
-                <li>Explorer: <a href="" target="_blank" class="bl-text-secondary-underline">https://explorer.testnet.ellaism.org</a></li>
-                <li>JSONRPC Endpoint: <a href="" target="_blank" class="bl-text-secondary-underline">
+                <li>Explorer: <a href="https://explorer.testnet.ellaism.org" target="_blank" class="bl-text-secondary-underline">https://explorer.testnet.ellaism.org</a></li>
+                <li>JSONRPC Endpoint: <a href="https://jsonrpc.testnet.ellaism.org" target="_blank" class="bl-text-secondary-underline">
                     https://jsonrpc.testnet.ellaism.org
                 </a></li>
            </ul>


### PR DESCRIPTION
Added links to shinkinseki config, ellism testnet explorer and testnet rpc endpoint.