### PR TITLE
Fix white text links

### DIFF
--- a/src/scss/base/base.scss
+++ b/src/scss/base/base.scss
@@ -35,7 +35,7 @@ body {
 }
 
 a {
-	color: $bl-secondary-color;
+  color: $bl-secondary-color;
   text-decoration: none;
   &:hover,
   &:active {
@@ -45,7 +45,7 @@ a {
 }
 
 .bl-text-white a {
-	color: $bl-white;
+  color: $bl-white;
 }
 
 ul li {

--- a/src/scss/base/base.scss
+++ b/src/scss/base/base.scss
@@ -34,14 +34,18 @@ body {
 // height:6018px; //delete
 }
 
-.bl-text-white a {
-  color: $bl-white;
+a {
+	color: $bl-secondary-color;
   text-decoration: none;
   &:hover,
   &:active {
     text-decoration: none;
     color: inherit;
   }
+}
+
+.bl-text-white a {
+	color: $bl-white;
 }
 
 ul li {

--- a/src/scss/base/base.scss
+++ b/src/scss/base/base.scss
@@ -34,7 +34,7 @@ body {
 // height:6018px; //delete
 }
 
-a {
+.bl-text-white a {
   color: $bl-white;
   text-decoration: none;
   &:hover,


### PR DESCRIPTION
Restore color of links on home page so they are white until hovered.  Reported by IngridFire.  They broke when I added CSS to style content pulled from the wiki.